### PR TITLE
Send credentials when requesting modules in noVNC

### DIFF
--- a/jwst-masterclass/base-environment.yml
+++ b/jwst-masterclass/base-environment.yml
@@ -3,5 +3,7 @@ channels:
 dependencies:
   - websockify==0.9.0
   - pip:
-    - https://github.com/jupyterhub/jupyter-server-proxy/archive/0e67e1afd0bab1342443f13bd147a2f8c682e9e0.zip
-    - jupyter-desktop-server==0.1.1
+    - git+https://github.com/jupyterhub/jupyter-server-proxy@4b5ec52
+    # This branch is adjusted to send credentials when making requests for imported
+    # modules in noVNC.
+    - git+https://github.com/eslavich/jupyter-desktop.git@eslavich-crossorigin-use-credentials


### PR DESCRIPTION
This fixes the issue with newer versions of Safari failing to connect to VNC.